### PR TITLE
fix: bump cloudposse/lb-s3-bucket/aws module version for the access…

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ module "alb" {
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_access_logs"></a> [access\_logs](#module\_access\_logs) | cloudposse/lb-s3-bucket/aws | 0.16.3 |
+| <a name="module_access_logs"></a> [access\_logs](#module\_access\_logs) | cloudposse/lb-s3-bucket/aws | 0.19.0 |
 | <a name="module_sg"></a> [sg](#module\_sg) | cloudposse/security-group/aws | 2.0.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 ## Resources

--- a/main.tf
+++ b/main.tf
@@ -28,7 +28,7 @@ resource "aws_lb" "default" {
 
 module "access_logs" {
   source  = "cloudposse/lb-s3-bucket/aws"
-  version = "0.16.3"
+  version = "0.19.0"
 
   enabled       = var.access_logs_enabled && local.enabled
   force_destroy = var.access_logs_force_destroy


### PR DESCRIPTION
fix: bump cloudposse/lb-s3-bucket/aws module version for the access_logs module in order to properly create the ACL


## Proposed Changes

 - [X] Bug fix
 - [ ] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build or CI related changes
 - [ ] Documentation content changes
 - [ ] Other, please describe:


## What is the current behavior?

Module is unable to apply a plan for the ACL on the access logs bucket.


## What is the new behavior?

Module will be able to apply a plan for the ACL on the access logs bucket.


## Checklist

Please check that your PR fulfills the following requirements:

- [X] Documentation has been added/updated.
- [ ] Automated tests for the changes have been added/updated.
- [ ] Commits have been squashed (if applicable).
- [ ] Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).


